### PR TITLE
Update the version of superagent.

### DIFF
--- a/lib/rongrequest.js
+++ b/lib/rongrequest.js
@@ -41,9 +41,9 @@ exports.request = function( api, params, format, callback ) {
 	.post( BASEURL + api + '.' + f )
 	.set( HEADERS )
 	.send( params )
-	.end( function( result ) {
-		if( result.err ) {
-			return callback( result.err, null );
+	.end( function( err, result ) {
+		if( err ) {
+			return callback( err, null );
 		}
 		else {
 			return callback( null, result.text );
@@ -76,9 +76,9 @@ exports.requestWithSameFields = function( api, params, fieldAndValues, format, c
 	}
 
 	agent.send( params )
-	.end( function( result ) {
-		if( result.err ) {
-			return callback( result.err, null );
+	.end( function( err, result ) {
+		if( err ) {
+			return callback( err, null );
 		}
 		else {
 			return callback( null, result.text );

--- a/package.json
+++ b/package.json
@@ -16,9 +16,9 @@
     "server",
     "sdk"
   ],
-  "dependencies" : {
-    "superagent" : ">=0.21.0",
-    "sha1"       : ">=1.1.0"
+  "dependencies": {
+    "sha1": ">=1.1.0",
+    "superagent": "^1.2.0"
   },
   "author": "RongCloud",
   "license": "MIT",


### PR DESCRIPTION
Since the newer version of superagent changes the callback arguments(changed to the standard nodejs callback with err and result), update the version and handle the arguments in the new style.
